### PR TITLE
Improvement on Skills and SelfBuffs

### DIFF
--- a/src/calc/jobs.js
+++ b/src/calc/jobs.js
@@ -110,13 +110,13 @@ export class Vagrant extends Mover {
 
 
 export class Assist extends Vagrant {
-    constructor(str = 15, sta = 15, int = 15, dex = 15, level = 1, constants = null, img = null, mainhand = null, offhand = null, armor = null, jobId = null) {
+    constructor(str = 15, sta = 15, int = 15, dex = 15, level = 15, constants = null, img = null, mainhand = null, offhand = null, armor = null, jobId = null) {
         jobId = jobId || 8962;
         img = img || "overamknuckle.png";
         armor = armor || Utils.getArmorByName("Sayram Set");
         mainhand = mainhand || Utils.getItemByName("Paipol Knuckle");
         constants = constants || {
-            'skills': [Utils.getSkillByName("Power Fist"),
+            'skills': [Utils.getSkillByName("Moon Beam"),
                 Utils.getSkillByName("Temping Hole"),
                 Utils.getSkillByName("Burst Crack")
             ],
@@ -163,7 +163,7 @@ export class Assist extends Vagrant {
 }
 
 export class Billposter extends Assist {
-    constructor(str = 15, sta = 15, int = 15, dex = 15, level = 1, constants = null, img = null, mainhand = null, offhand = null, armor = null, jobId = null) {
+    constructor(str = 15, sta = 15, int = 15, dex = 15, level = 60, constants = null, img = null, mainhand = null, offhand = null, armor = null, jobId = null) {
         jobId = jobId || 7424;
         img = img || "bloodyknuckle.png";
         armor = armor || Utils.getArmorByName("Rody Set");
@@ -173,7 +173,8 @@ export class Billposter extends Assist {
                 Utils.getSkillByName("Blood Fist"),
                 Utils.getSkillByName("Asalraalaikum")
             ],
-            'buffs': [Utils.getSkillByName("Asmodeus")],
+            'buffs': [Utils.getSkillByName("Asmodeus"),
+                Utils.getSkillByName("Stonehand")],
             'attackSpeed': 82.0,
             'hps': 2.5,
             'HP': 1.8,
@@ -216,7 +217,7 @@ export class Billposter extends Assist {
 }
 
 export class Ringmaster extends Assist {
-    constructor(str = 15, sta = 15, int = 15, dex = 15, level = 1, constants = null, img = null, mainhand = null, offhand = null, armor = null, jobId = null) {
+    constructor(str = 15, sta = 15, int = 15, dex = 15, level = 60, constants = null, img = null, mainhand = null, offhand = null, armor = null, jobId = null) {
         jobId = jobId || 9389;
         img = img || "lgstick.png";
         armor = armor || Utils.getArmorByName("Rimyth Set");
@@ -272,14 +273,14 @@ export class Ringmaster extends Assist {
 }
 
 export class Acrobat extends Vagrant {
-    constructor(str = 15, sta = 15, int = 15, dex = 15, level = 1, constants = null, img = null, mainhand = null, offhand = null, armor = null, jobId = null) {
+    constructor(str = 15, sta = 15, int = 15, dex = 15, level = 15, constants = null, img = null, mainhand = null, offhand = null, armor = null, jobId = null) {
         jobId = jobId || 9098;
         img = img || "layeredbow.png";
         armor = armor || Utils.getArmorByName("Cruiser Set");
         mainhand = mainhand || Utils.getItemByName("Layered Bow");
         constants = constants || {
             'skills': [Utils.getSkillByName("Junk Arrow"),
-                Utils.getSkillByName("Silent Shot"),
+                Utils.getSkillByName("Slow Step"),
                 Utils.getSkillByName("Arrow Rain")
             ],
             'buffs': [Utils.getSkillByName("Perfect Block"),
@@ -330,7 +331,7 @@ export class Acrobat extends Vagrant {
 }
 
 export class Jester extends Acrobat {
-    constructor(str = 15, sta = 15, int = 15, dex = 15, level = 1, constants = null, img = null, mainhand = null, offhand = null, armor = null, jobId = null) {
+    constructor(str = 15, sta = 15, int = 15, dex = 15, level = 60, constants = null, img = null, mainhand = null, offhand = null, armor = null, jobId = null) {
         jobId = jobId || 3545;
         img = img || "lgyoyo.png";
         armor = armor || Utils.getArmorByName("Neis Set");
@@ -343,7 +344,8 @@ export class Jester extends Acrobat {
             'buffs': [Utils.getSkillByName("Critical Swing"),
                 Utils.getSkillByName("Enchant Absorb"),
                 Utils.getSkillByName("Yo-Yo Mastery"),
-                Utils.getSkillByName("Bow Mastery")
+                Utils.getSkillByName("Bow Mastery"),
+                Utils.getSkillByName("Perfect Block")
             ],
             'attackSpeed': 82.0,
             'hps': 2.6,
@@ -388,7 +390,7 @@ export class Jester extends Acrobat {
 }
 
 export class Ranger extends Acrobat {
-    constructor(str = 15, sta = 15, int = 15, dex = 15, level = 1, constants = null, img = null, mainhand = null, offhand = null, armor = null, jobId = null) {
+    constructor(str = 15, sta = 15, int = 15, dex = 15, level = 60, constants = null, img = null, mainhand = null, offhand = null, armor = null, jobId = null) {
         jobId = jobId || 9295;
         img = img || "lgbow.png";
         armor = armor || Utils.getArmorByName("Tyrent Set");
@@ -400,7 +402,7 @@ export class Ranger extends Acrobat {
             ],
             'buffs': [Utils.getSkillByName("Critical Shot"),
                 Utils.getSkillByName("Nature"),
-                Utils.getSkillByName("Yo-Yo Mastery"),
+                Utils.getSkillByName("Perfect Block"),
                 Utils.getSkillByName("Bow Mastery")
             ],
             'attackSpeed': 77.0,
@@ -446,7 +448,7 @@ export class Ranger extends Acrobat {
 }
 
 export class Magician extends Vagrant {
-    constructor(str = 15, sta = 15, int = 15, dex = 15, level = 1, constants = null, img = null, mainhand = null, offhand = null, armor = null, jobId = null) {
+    constructor(str = 15, sta = 15, int = 15, dex = 15, level = 15, constants = null, img = null, mainhand = null, offhand = null, armor = null, jobId = null) {
         jobId = jobId || 9581;
         img = img || "opelwand.png";
         armor = armor || Utils.getArmorByName("Teba Set");
@@ -499,7 +501,7 @@ export class Magician extends Vagrant {
 }
 
 export class Psykeeper extends Magician {
-    constructor(str = 15, sta = 15, int = 15, dex = 15, level = 1, constants = null, img = null, mainhand = null, offhand = null, armor = null, jobId = null) {
+    constructor(str = 15, sta = 15, int = 15, dex = 15, level = 60, constants = null, img = null, mainhand = null, offhand = null, armor = null, jobId = null) {
         jobId = jobId || 5709;
         img = img || "lgwand.png";
         armor = armor || Utils.getArmorByName("Mekatro Set");
@@ -507,7 +509,7 @@ export class Psykeeper extends Magician {
         constants = constants || {
             'skills': [Utils.getSkillByName("Psychic Bomb"),
                 Utils.getSkillByName("Spirit Bomb"),
-                Utils.getSkillByName("Psychic Square")
+                Utils.getSkillByName("Maximum Crisis")
             ],
             'buffs': [],
             'attackSpeed': 67.0,
@@ -552,7 +554,7 @@ export class Psykeeper extends Magician {
 }
 
 export class Elementor extends Magician {
-    constructor(str = 15, sta = 15, int = 15, dex = 15, level = 1, constants = null, img = null, mainhand = null, offhand = null, armor = null, jobId = null) {
+    constructor(str = 15, sta = 15, int = 15, dex = 15, level = 60, constants = null, img = null, mainhand = null, offhand = null, armor = null, jobId = null) {
         jobId = jobId || 9150;
         img = img || "lgstaff.png";
         armor = armor || Utils.getArmorByName("Shabel Set");
@@ -610,18 +612,20 @@ export class Elementor extends Magician {
 }
 
 export class Mercenary extends Vagrant {
-    constructor(str = 15, sta = 15, int = 15, dex = 15, level = 1, constants = null, img = null, mainhand = null, offhand = null, armor = null, jobId = null) {
+    constructor(str = 15, sta = 15, int = 15, dex = 15, level = 15, constants = null, img = null, mainhand = null, offhand = null, armor = null, jobId = null) {
         jobId = jobId || 764;
         img = img || "woodensword.png";
         armor = armor || Utils.getArmorByName("Panggril Set");
         mainhand = mainhand || Utils.getItemByName("Flam Sword");
+        offhand = offhand || Utils.getItemByName("Avalon Shield");
         constants = constants || {
-            'skills': [Utils.getSkillByName("Shield Bash"),
+            'skills': [Utils.getSkillByName("Slash"),
                 Utils.getSkillByName("Keenwheel"),
                 Utils.getSkillByName("Guillotine")
             ],
             'buffs': [Utils.getSkillByName("Blazing Sword"),
-                Utils.getSkillByName("Sword Mastery")
+                Utils.getSkillByName("Sword Mastery"),
+                Utils.getSkillByName("Protection")                
             ],
             'attackSpeed': 77.0,
             'hps': 4,
@@ -665,7 +669,7 @@ export class Mercenary extends Vagrant {
 }
 
 export class Blade extends Mercenary {
-    constructor(str = 15, sta = 15, int = 15, dex = 15, level = 1, constants = null, img = null, mainhand = null, offhand = null, armor = null, jobId = null) {
+    constructor(str = 15, sta = 15, int = 15, dex = 15, level = 60, constants = null, img = null, mainhand = null, offhand = null, armor = null, jobId = null) {
         jobId = jobId || 2246;
         img = img || "lgaxe.png";
         armor = armor || Utils.getArmorByName("Hanes Set");
@@ -673,13 +677,14 @@ export class Blade extends Mercenary {
         offhand = offhand || Utils.getItemByName("Legendary Golden Axe");
         constants = constants || {
             'skills': [Utils.getSkillByName("Blade Dance"),
-                Utils.getSkillByName("Hawk Attack"),
+                Utils.getSkillByName("Silent Strike"),
                 Utils.getSkillByName("Cross Strike"),
             ],
             'buffs': [Utils.getSkillByName("Berserk"),
                 Utils.getSkillByName("Smite Axe"),
                 Utils.getSkillByName("Axe Mastery"),
                 Utils.getSkillByName("Sword Mastery"),
+                Utils.getSkillByName("Blazing Sword"),
                 Utils.getSkillByName("Protection")],
             'attackSpeed': 87.0,
             'hps': 3,
@@ -723,7 +728,7 @@ export class Blade extends Mercenary {
 }
 
 export class Knight extends Mercenary {
-    constructor(str = 15, sta = 15, int = 15, dex = 15, level = 1, constants = null, img = null, mainhand = null, offhand = null, armor = null, jobId = null) {
+    constructor(str = 15, sta = 15, int = 15, dex = 15, level = 60, constants = null, img = null, mainhand = null, offhand = null, armor = null, jobId = null) {
         jobId = jobId || 5330;
         img = img || "lgswt.png";
         armor = armor || Utils.getArmorByName("Extro Set");
@@ -737,6 +742,7 @@ export class Knight extends Mercenary {
                 Utils.getSkillByName("Smite Axe"),
                 Utils.getSkillByName("Axe Mastery"),
                 Utils.getSkillByName("Sword Mastery"),
+                Utils.getSkillByName("Blazing Sword"),
                 Utils.getSkillByName("Protection")],
             'attackSpeed': 77.0,
             'hps': 2,

--- a/src/calc/mover.js
+++ b/src/calc/mover.js
@@ -75,6 +75,8 @@ export class Mover {
             this.activeSelfBuffs = [];
         }
 
+        
+
         // Check if there are buffs we can add that are not currently active
         for (let buff of this.constants.buffs) {
             if (buff.level <= this.level && !this.activeSelfBuffs.includes(buff)) {
@@ -84,7 +86,8 @@ export class Mover {
         }
 
         if (this.selfBuffs && this.activeSelfBuffs.length == 0) {
-            this.activeSelfBuffs = this.constants.buffs.filter(b => b.level <= this.level);
+            this.activeSelfBuffs = this.constants.buffs.filter(b => b.level <= this.level && //
+            this.applySelfBuffFilterBasedOnWeapon(b, this.mainhand.subcategory, this.offhand)); // filter buffs according weapon type
 
             this.str += this.selfBuffParam('str');
             this.sta += this.selfBuffParam('sta');
@@ -97,6 +100,18 @@ export class Mover {
             this.dex -= this.selfBuffParam('dex');
 
             this.activeSelfBuffs = [];
+        }
+    }
+
+    applySelfBuffFilterBasedOnWeapon(selfBuff, mainhandweapon, offhandweapon) {
+        if(selfBuff.weapon == null) { // some buffs have no weapon
+            return true;
+        }
+        if(offhandweapon != null && offhandweapon.subcategory != null && selfBuff.weapon.includes(offhandweapon.subcategory)) { // offhand logic for shield
+            return true;
+        }
+        if(selfBuff.weapon.includes(mainhandweapon)) { // main check
+            return true;
         }
     }
 

--- a/src/calc/utils.js
+++ b/src/calc/utils.js
@@ -111,6 +111,17 @@ export class Utils {
         return 0;
     }
 
+    static sortByLevel(a, b) {
+        if (a.level < b.level) {
+            return -1;
+        }
+        if (a.level > b.level) {
+            return 1;
+        }
+
+        return 0;
+    }
+
     updateJob(character, job) {
         if (character.constructor.name != job) { 
             let stats = {

--- a/src/components/Leftbar/Equipment.vue
+++ b/src/components/Leftbar/Equipment.vue
@@ -37,7 +37,7 @@
             <select v-model="character.mainhand" id="equipment-select">
               <option disabled value="">Select a weapon...</option>
               <option v-for="weapon in weapons" :value="weapon" :key="weapon.id">
-                {{ weapon.name.en }}
+                Lv. {{ weapon.level }} {{ weapon.name.en }}
               </option>
             </select>
           </td>
@@ -62,7 +62,7 @@
             <select v-model="character.offhand" id="equipment-select" :disabled=!canUseOffhand>
               <option disabled value="">Select an offhand...</option>
               <option v-for="offhand in offhands" :value="offhand" :key="offhand.id">
-                {{ offhand.name.en }}
+                Lv. {{ offhand.level }} {{ offhand.name.en }}
               </option>
           </select>
           </td>
@@ -89,7 +89,7 @@
             <select v-model="character.earringR" id="equipment-select">
               <option disabled value="">Select an earring...</option>
               <option v-for="earring in earrings" :value="earring" :key="earring.id">
-                {{ earring.name.en }}
+                Lv. {{ earring.level }} {{ earring.name.en }}
               </option>
             </select>
           </td>
@@ -104,7 +104,7 @@
             <select v-model="character.earringL" id="equipment-select">
               <option disabled value="">Select an earring...</option>
               <option v-for="earring in earrings" :value="earring" :key="earring.id">
-                {{ earring.name.en }}
+                Lv. {{ earring.level }} {{ earring.name.en }}
               </option>
             </select>
           </td>
@@ -119,7 +119,7 @@
             <select v-model="character.necklace" id="equipment-select">
               <option disabled value="">Select a necklace...</option>
               <option v-for="necklace in necklaces" :value="necklace" :key="necklace.id">
-                {{ necklace.name.en }}
+                Lv. {{ necklace.level }} {{ necklace.name.en }}
               </option>
             </select>
           </td>
@@ -134,7 +134,7 @@
             <select v-model="character.ringR" id="equipment-select">
               <option disabled value="">Select a ring...</option>
               <option v-for="ring in rings" :value="ring" :key="ring.id">
-                {{ ring.name.en }}
+                Lv. {{ ring.level }} {{ ring.name.en }}
               </option>
             </select>
           </td>
@@ -149,7 +149,7 @@
             <select v-model="character.ringL" id="equipment-select">
               <option disabled value="">Select a ring...</option>
               <option v-for="ring in rings" :value="ring" :key="ring.id">
-                {{ ring.name.en }}
+                Lv. {{ ring.level }} {{ ring.name.en }}
               </option>
           </select>
           </td>
@@ -204,7 +204,7 @@ export default {
     this.rings = Utils.getJewelery("ring").sort(Utils.sortByName);
     this.necklaces = Utils.getJewelery("necklace").sort(Utils.sortByName);
     this.piercingCards = Utils.getPiercingCards().sort(Utils.sortByName);
-    this.shields = Utils.getShields().sort(Utils.sortByName);
+    this.shields = Utils.getShields().sort(Utils.sortByLevel);
 
     this.offhands = [...this.shields];
     if (this.character instanceof Blade) {
@@ -213,7 +213,7 @@ export default {
   },
   methods: {
     updateEquipment() {
-      this.weapons = Utils.getJobWeapons(this.character.jobId).sort(Utils.sortByName);
+      this.weapons = Utils.getJobWeapons(this.character.jobId).sort(Utils.sortByLevel);
       this.armors = Utils.getJobArmors(this.character.jobId).sort(Utils.sortByName);
 
       // Blades can use a shield or a weapon in their offhand


### PR DESCRIPTION
- Added preselected Avalon Shield to Mercenary
- Changed selfbuff logic to apply only selfbuffs for correct weapon type. Includes shields in offhand. I have tested all classes. You may double check.

**Further Skill & Buff changes:**

Assist
Skills: added Moon Beam, removed Power Fist

Acrobat
Skills: added Slow Step, removed Silent Shot

Mercenary
Skills: added Slash, removed Shield Bash
Buffs: added Protection

Jester
Buffs: added Perfect Block

Ranger
Buffs: added Perfect Block, removed Yoyo Mastery

Psykeeper
Skills: added Maximum Crisis, removed Psychic Square

Blade
Skills: added Silent Strike, removed Hawk Attack

Billposter
Buffs: added Stone Hand

(Sorry my previous changes with the level infront of the name i have done on the master, instead of the branch - so they are included here now. I don't know how to filter them out here)