### PR TITLE
buffs applied based on weapon, several skill/buff changes

### DIFF
--- a/src/calc/jobs.js
+++ b/src/calc/jobs.js
@@ -118,8 +118,9 @@ export class Assist extends Vagrant {
         img = img || "overamknuckle.png";
         armor = armor || Utils.getArmorByName("Sayram Set");
         mainhand = mainhand || Utils.getItemByName("Paipol Knuckle");
+        offhand = offhand || Utils.getItemByName("Avalon Shield");
         constants = constants || {
-            'skills': [Utils.getSkillByName("Power Fist"),
+            'skills': [Utils.getSkillByName("Moon Beam"),
                 Utils.getSkillByName("Temping Hole"),
                 Utils.getSkillByName("Burst Crack")
             ],
@@ -178,7 +179,8 @@ export class Billposter extends Assist {
                 Utils.getSkillByName("Blood Fist"),
                 Utils.getSkillByName("Asalraalaikum")
             ],
-            'buffs': [Utils.getSkillByName("Asmodeus")],
+            'buffs': [Utils.getSkillByName("Asmodeus"),
+                Utils.getSkillByName("Stonehand")],
             'attackSpeed': 82.0,
             'hps': 2.5,
             'HP': 1.8,
@@ -353,8 +355,11 @@ export class Jester extends Acrobat {
             ],
             'buffs': [Utils.getSkillByName("Critical Swing"),
                 Utils.getSkillByName("Enchant Absorb"),
+                Utils.getSkillByName("Enchant Blood"),
+                Utils.getSkillByName("Enchant Poison"),
                 Utils.getSkillByName("Yo-Yo Mastery"),
-                Utils.getSkillByName("Bow Mastery")
+                Utils.getSkillByName("Bow Mastery"),
+                Utils.getSkillByName("Perfect Block")
             ],
             'attackSpeed': 82.0,
             'hps': 2.6,
@@ -413,8 +418,8 @@ export class Ranger extends Acrobat {
             ],
             'buffs': [Utils.getSkillByName("Critical Shot"),
                 Utils.getSkillByName("Nature"),
-                Utils.getSkillByName("Yo-Yo Mastery"),
-                Utils.getSkillByName("Bow Mastery")
+                Utils.getSkillByName("Bow Mastery"),
+                Utils.getSkillByName("Perfect Block")
             ],
             'attackSpeed': 77.0,
             'hps': 2.14,
@@ -636,13 +641,17 @@ export class Mercenary extends Vagrant {
         img = img || "woodensword.png";
         armor = armor || Utils.getArmorByName("Panggril Set");
         mainhand = mainhand || Utils.getItemByName("Flam Sword");
+        offhand = offhand || Utils.getItemByName("Avalon Shield");
         constants = constants || {
-            'skills': [Utils.getSkillByName("Shield Bash"),
+            'skills': [Utils.getSkillByName("Slash"),
                 Utils.getSkillByName("Keenwheel"),
                 Utils.getSkillByName("Guillotine")
             ],
             'buffs': [Utils.getSkillByName("Blazing Sword"),
-                Utils.getSkillByName("Sword Mastery")
+                Utils.getSkillByName("Sword Mastery"),
+                Utils.getSkillByName("Smite Axe"),
+                Utils.getSkillByName("Axe Mastery"),
+                Utils.getSkillByName("Protection")
             ],
             'attackSpeed': 77.0,
             'hps': 4,
@@ -696,13 +705,16 @@ export class Blade extends Mercenary {
         offhand = offhand || Utils.getItemByName("Legendary Golden Axe");
         constants = constants || {
             'skills': [Utils.getSkillByName("Blade Dance"),
-                Utils.getSkillByName("Hawk Attack"),
+                Utils.getSkillByName("Spring Attack"),
                 Utils.getSkillByName("Cross Strike"),
             ],
             'buffs': [Utils.getSkillByName("Berserk"),
                 Utils.getSkillByName("Smite Axe"),
                 Utils.getSkillByName("Axe Mastery"),
-                Utils.getSkillByName("Sword Mastery")],
+                Utils.getSkillByName("Blazing Sword"),
+                Utils.getSkillByName("Sword Mastery"),
+                Utils.getSkillByName("Protection")
+            ],
             'attackSpeed': 87.0,
             'hps': 3,
             'HP': 1.5,
@@ -760,6 +772,7 @@ export class Knight extends Mercenary {
             'buffs': [Utils.getSkillByName("Rage"),
                 Utils.getSkillByName("Smite Axe"),
                 Utils.getSkillByName("Axe Mastery"),
+                Utils.getSkillByName("Blazing Sword"),
                 Utils.getSkillByName("Sword Mastery"),
                 Utils.getSkillByName("Protection")],
             'attackSpeed': 77.0,

--- a/src/calc/mover.js
+++ b/src/calc/mover.js
@@ -59,6 +59,7 @@ export class Mover {
             for (let buff of this.constants.buffs) {
                 if (this.activeBuffs.find(b => b.id == buff.id)) continue;
                 if (buff.level > this.level) continue;
+
                 buff.enabled = true;
                 this.activeBuffs.push(buff);
             }
@@ -67,6 +68,12 @@ export class Mover {
                 return !this.constants.buffs.find(b => b.id == val.id);
             });
         }
+
+        // Remove any buffs not matching the selected weapon
+        this.activeBuffs = this.activeBuffs.filter(buff => buff.weapon  == null // some buffs have no weapon
+        || (this.offhand != null && this.offhand.subcategory != null && buff.weapon.includes(this.offhand.subcategory)) // offhand logic for shield
+        || buff.weapon.includes(this.mainhand.subcategory) // buff weapon doesn't match select mainhand weapon
+        );
 
         // Remove any buffs above our level
         this.activeBuffs = this.activeBuffs.filter((val, index, arr) => {
@@ -705,6 +712,12 @@ export class Mover {
                 break;
             case 7023: // Multi-Stab
                 final *= 7; // Hits 7 times in the animation
+                break;
+            case 9538: // Spring Attack
+                final *= 5; // Hits 5 times in the animation - actually 15% to double the dmg each hit
+                break;
+            case 4448: // Belial Smashing
+                final *= 5; // Hits 5 times in the animation - actually 15% to double the dmg each hit
                 break;
             case 1526: // Junk Arrow
                 final *= maxLevel.probability / 100.0;


### PR DESCRIPTION
1. Changed selfbuff logic to apply only selfbuffs for correct weapon type. Includes shields in offhand.

2. Several updates on skills/buffs
Assist
- Replaced "Power Fist" with "Moon Beam" for support assists
- Added preselect "Avalon Shield"

Mercenary
- Added "Smite Axe", "Axe Mastery" and "Protection" buffs
- Replaced "Shiled Bash" with "Slash"
- Added preselect "Avalon Shield"

Blade
- "Spring Attack" hits 5 times
- Added "Blazing Sword" buff
- Added "Protection" buff

Jester
- Added "Enchant Blood" and "Enchant Poison" buffs, so players can free select which one shall apply
- Added "Perfect Block" buff

Ranger
- Removed "Yo-Yo Mastery" buff
- Added "Perfect Block" buff

Billposter
- "Belial Smashing" hits 5 times
- Added "Stone Hand" buff

Knight
- Added "Blazing Sword" buff