### PR TITLE
premium items panel for charakter configuration

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -127,6 +127,7 @@ export default {
     'character.ref.assistInt'() { this.updateCharacter() },
     'character.ref.selfBuffs'() { this.updateCharacter() },
     'character.ref.assistBuffs'() { this.updateCharacter() },
+    'character.ref.premiumItems'() { this.updateCharacter() },
     'character.ref.mainhand'() { this.updateCharacter() },
     'character.ref.offhand'() { this.updateCharacter() },
     'character.ref.armor'() { this.updateCharacter() },
@@ -187,8 +188,13 @@ export default {
       return images('./' + img)
     },
     getIconUrl(img) {
-      var images = require.context('./assets/images/Icons/Items', false, /\.png$/)
-      return images('./' + img)
+      try {
+        var images = require.context('./assets/images/Icons/Items', false, /\.png$/)
+        return images('./' + img)
+      } catch(error) {
+        // dummy icon if icon couldn't be found
+        return images('./' + "syssysqueheadrb.png")
+      }
     },
     getSkillIconUrl(img) {
       var images = require.context('./assets/images/Icons/Skills/colored', false, /\.png$/)

--- a/src/calc/jobs.js
+++ b/src/calc/jobs.js
@@ -25,6 +25,7 @@ export class Vagrant extends Mover {
         this.shield = null;
         this.assistBuffs = false;
         this.selfBuffs = false;
+        this.premiumItems = false;
         this.constants = constants || {
             'skills': [Utils.getSkillByName("Clean Hit"),
                 Utils.getSkillByName("Flurry"),
@@ -66,6 +67,7 @@ export class Vagrant extends Mover {
         this.activeAssistBuffs = [];
         this.activeSelfBuffs = [];
         this.activeBuffs = [];
+        this.activePremiumItems = [];
         this.assistInt = 300; // How much int the assist buffing you has
 
         this.monsters = [];

--- a/src/calc/mover.js
+++ b/src/calc/mover.js
@@ -14,6 +14,7 @@ export class Mover {
         this.offhandUpgradeBonus = Utils.getUpgradeBonus(this.offhandUpgrade);
         
         this.applyBuffs();
+        this.applyPremiumItems();
         this.applyBaseStats();
 
         this.str = Math.floor(this.str);
@@ -72,6 +73,16 @@ export class Mover {
         this.activeBuffs = this.activeBuffs.filter((val, index, arr) => {
             return val.level <= this.level || val.class == 9389 || val.class == 8962;
         });
+    }
+
+    applyPremiumItems() {
+        for (let item of Moverutils.premiumItems) {
+            if(item) {
+                if (this.activePremiumItems.find(i => i.id == item.id)) continue;
+                item.enabled = false; // disable all items initially
+                this.activePremiumItems.push(item);
+            }
+        }
     }
 
     get parry() {
@@ -339,7 +350,7 @@ export class Mover {
     }
 
     getExtraBuffParam(param, rate = false) {
-        return this.buffParam(param, rate);
+        return this.buffParam(param, rate) + this.premiumItemParam(param, rate);
         // return this.assistBuffParam(param, rate) + this.selfBuffParam(param, rate);
     }
 
@@ -458,6 +469,28 @@ export class Mover {
                             }
                         }
                     }
+                }
+            }
+        }
+
+        return add;
+    }
+
+    /**
+     * Returns additions to a specific value from your active & enabled premium items
+     * @param param The value to find additions for 
+     */
+     premiumItemParam(param, rate=false) {
+        let add = 0;
+        let params = [param].concat(Utils.globalParams[param]);
+
+        for (let premiumItem of this.activePremiumItems) {
+            if (!premiumItem.enabled) continue;    // Don't add disabled buffs
+            let abilities = premiumItem.abilities;
+            
+            for (let ability of abilities) {
+                if (params.includes(ability.parameter) && ability.rate == rate) {
+                    add += ability.add;
                 }
             }
         }

--- a/src/calc/moverutils.js
+++ b/src/calc/moverutils.js
@@ -17,6 +17,40 @@ export default class Moverutils {
         Utils.getSkillByName('Geburah Tiphreth')
     ];
 
+    static premiumItems = [
+        Utils.getItemByName('Grilled Eel'),
+        // Utils.getItemByName('Upcut Stone'), // incorrect item. its a scroll type, not buff and has no abilities. api issue
+        Utils.getItemByName('Def-Upcut Stone'),
+        Utils.getItemByName('Power Scroll'),
+        Utils.getItemByName('Charged Power Scroll'),
+        Utils.getItemByName('Super Charged Power Scroll'),
+        Utils.getItemByName('Flask of the Tiger'),
+        Utils.getItemByName('Flask of the Lion'),
+        Utils.getItemByName('Flask of the Rabbit'),
+        Utils.getItemByName('Flask of the Fox'),
+        Utils.getItemByName('Flask of Stone'),
+        Utils.getItemByName('Potion of Recklessness'),
+        Utils.getItemByName('Potion of Swiftness'),
+        Utils.getItemByName('Potion of Clarity'),
+        Utils.getItemByName('Elixir of the Sorceror'),
+        Utils.getItemByName('Elixir of Anti-Magic'),
+        Utils.getItemByName('Elixir of Evasion'),
+        Utils.getItemByName('Concoction of Profuse Bleeding'),
+        Utils.getItemByName('Green Cotton Candy'),
+        Utils.getItemByName('Purple Cotton Candy'),
+        Utils.getItemByName('Orange Cotton Candy'),
+        Utils.getItemByName('Yellow Cotton Candy'),
+        Utils.getItemByName('Red Cotton Candy'),
+        Utils.getItemByName('Gray Cotton Candy'),
+        Utils.getItemByName('Blue Cotton Candy'),
+        Utils.getItemByName('Pink Cotton Candy'),
+        Utils.getItemByName('White Cotton Candy'),
+        Utils.getItemByName('Sky-Blue Cotton Candy'),
+        Utils.getItemByName('Yellow Balloons'),
+        Utils.getItemByName('Pink Balloons'),
+        Utils.getItemByName('Blue Balloons')
+    ];
+
     static trainingDummy = {
         "defense": 133,
         "sta": 1,

--- a/src/calc/utils.js
+++ b/src/calc/utils.js
@@ -27,6 +27,7 @@ export class Utils {
     static assistInt = 300;
     static assistBuffs = false;
     static classBuffs = false;
+    static premiumItems = false;
 
     static maxLevel = 120;
 

--- a/src/components/AutoRatio.vue
+++ b/src/components/AutoRatio.vue
@@ -195,6 +195,7 @@ export default {
     '$root.focusMonster'() { this.getTheoreticalAADPS(); },
     '$root.character.ref.level'() { this.getTheoreticalAADPS(); },
     '$root.character.ref.assistBuffs'() { this.getTheoreticalAADPS(); },
+    '$root.character.ref.premiumItems'() { this.getTheoreticalAADPS(); },
     '$root.character.ref.selfBuffs'() { this.getTheoreticalAADPS(); },
     '$root.character.ref.mainhand'() { this.getTheoreticalAADPS(); },
     '$root.character.ref.armor'() { this.getTheoreticalAADPS(); },

--- a/src/components/Leftbar.vue
+++ b/src/components/Leftbar.vue
@@ -5,6 +5,7 @@
             <character ref="character" />
             <equipment ref="equipment" />
             <buffs/>
+            <premiumitems/>
             <!--<externals/>-->
         </div>
     </div>
@@ -15,6 +16,7 @@ import Character from './Leftbar/Character.vue'
 import Equipment from './Leftbar/Equipment.vue'
 import Buffs from './Leftbar/Buffs.vue'
 import Builds from './Leftbar/Builds.vue'
+import Premiumitems from './Leftbar/Premiumitems.vue'
 //import Externals from './Leftbar/External.vue'
 //import Changelog from './Leftbar/Changelog.vue'
 
@@ -24,7 +26,8 @@ export default {
       Character,
       Equipment,
       Buffs,
-      Builds
+      Builds,
+      Premiumitems
       //Changelog,
       //Externals
   },

--- a/src/components/Leftbar/Builds.vue
+++ b/src/components/Leftbar/Builds.vue
@@ -105,6 +105,7 @@ export default {
           assistint: Utils.assistInt,
           assistbuffs: Utils.assistBuffs,
           classbuffs: Utils.classBuffs,
+          premiumItems: Utils.premiumItems
         };
 
         const newEquipment = {

--- a/src/components/Leftbar/Character.vue
+++ b/src/components/Leftbar/Character.vue
@@ -112,6 +112,14 @@
           </tr>
 
           <tr>
+            <td><h5>Premium items</h5></td>
+            <td></td>
+            <td>
+              <input id="premiumItems" type="checkbox" v-model="premiumItems">
+            </td>
+          </tr>
+
+          <tr>
             <td><h5>Stat points</h5></td>
             <td></td>
             <td><h5 :class="{'red-text' : statpoints < 0 }">{{statpoints}}</h5></td>
@@ -145,6 +153,7 @@ export default {
       addint: 0,
       added: 0,
       assistbuffs: false,
+      premiumItems: false,
       assistint: 300,
       classbuffs: false,
       statpoints: 0,
@@ -210,6 +219,7 @@ export default {
       this.character.ref.assistInt = this.assistint;
       this.character.ref.assistBuffs = this.assistbuffs;
       this.character.ref.selfBuffs = this.classbuffs;
+      this.character.ref.premiumItems = this.premiumItems;
     },
     applyLoadedStats(appliedStats){      
       this.character.ref = new Vagrant();
@@ -227,6 +237,7 @@ export default {
       this.character.ref.int = appliedStats.int;
       this.assistint = appliedStats.assistint;
       this.assistbuffs = appliedStats.assistbuffs;
+      this.premiumItems = appliedStats.premiumItems;
       this.classbuffs = appliedStats.classbuffs;
       this.addstr = 0;
       this.addsta = 0;
@@ -248,6 +259,7 @@ export default {
       Utils.addedInt = 0;
       this.classbuffs = false;
       this.assistbuffs = false;
+      this.premiumItems = false;
       this.assistint = 300;
       this.added = 0;
 
@@ -289,6 +301,9 @@ export default {
     },
     assistbuffs() {
       Utils.assistBuffs = this.assistbuffs;
+    },
+    premiumItems() {
+      Utils.premiumItems = this.premiumItems;
     },
     classbuffs() {
       Utils.classBuffs = this.classbuffs;

--- a/src/components/Leftbar/Premiumitems.vue
+++ b/src/components/Leftbar/Premiumitems.vue
@@ -1,0 +1,95 @@
+<template>
+  <div class="char">
+    <h3>Premium Items</h3>
+    <h5>Add premium items through the 'Your Character' module</h5>
+    <div class="stats">
+      <ul>
+        <li v-for="premiumItem in premiumItems" :value="premiumItem" :key="premiumItem.id">
+          <input type="checkbox" name="enable-premiumItem" id="enable-premiumItem" v-model="premiumItem.enabled" @change="reloadPremiumItems">
+          <img :src="$root.getIconUrl(premiumItem.icon)" alt="" :title="getTooltip(premiumItem)" :class="{'disabled' : premiumItem.enabled == false }">
+        </li>
+      </ul>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'Premiumitems',
+  data() {
+    return {
+      character: this.$root.character.ref,
+      premiumItems: []
+    }
+  },
+  mounted() {
+    this.updatePremiumItems();
+  },
+  methods: {
+    updatePremiumItems() {
+      this.premiumItems = [];
+      this.premiumItems = this.character.activePremiumItems;
+    },
+    reloadPremiumItems() {
+      this.character.update();
+    },
+    getTooltip(premiumItem) {
+      let tooltip = premiumItem.name.en + "\n";
+      if(premiumItem.abilities) {
+        premiumItem.abilities.forEach(ability => {
+          let effect = "";
+          effect += ability.parameter;
+          let add = ability.add;
+          effect += "+" + add;
+          if (ability.rate) effect += "%";
+          effect += "\n";
+          tooltip += effect;
+        });
+      }
+      return tooltip;
+    }
+  },
+  watch: {
+    '$root.character.ref.activePremiumItems'() {
+      this.character = this.$root.character.ref;
+      this.updatePremiumItems();
+    }
+  }
+}
+</script>
+
+<style scoped lang='scss'>
+ul {
+    list-style: none;
+    padding: 10px;
+    width: 100%;
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+}
+
+li {
+  position: relative;
+}
+
+h5 {
+  opacity: 0.5;
+  margin: 0;
+  margin-bottom: 20px;
+}
+
+input[type=checkbox] {
+  position: absolute;
+  opacity: 0.8;
+  z-index: 200;
+}
+
+img {
+  transition: 0.2s;
+  
+  &.disabled {
+    opacity: 0.2;
+    transition: 0.2s;
+  }
+}
+</style>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/105540900/172617338-640cfeed-d2d7-42f1-8dae-7c77d2255dc8.png)

added premium item panel. i had to add them manually, similar to the buffs, since there is no possibility to reduce the set of items properly. it just contains to much different stuff.
- upcut stone is bugged in the api. it is in scroll category, and not buff. furthermore, it has no abilities defined.
- rainbow cotton candy is missing in the api, so not added yet.
- some items do miss their icon in flyffulator. the icon is in the api, since you can see it in the wiki. so i guess you trigger a manual update of the icons? for now i added a try catch and return some "dummy" icon.