### PR TITLE
Fixes #76 - Empty job name in select menu

### DIFF
--- a/src/calc/utils.js
+++ b/src/calc/utils.js
@@ -244,7 +244,8 @@ export class Utils {
     }
 
     static updateJob(character, job) {
-        if (character.constructor.name != job) {
+        const currentCharacterJobName = this.getJobName(character.jobId);
+        if (currentCharacterJobName != job) {
             let stats = {
                 str: character.str,
                 sta: character.sta,

--- a/src/components/DamageBox.vue
+++ b/src/components/DamageBox.vue
@@ -6,7 +6,7 @@ const props = defineProps(["character", "focus", "skill"]);
 const skills = reactive({ data: Utils.getJobSkills(props.character.data.jobId) });
 
 watch(
-    () => props.character.data.constructor.name,
+    () => props.character.data.jobId,
     () => {
         skills.data = Utils.getJobSkills(props.character.data.jobId);
     }

--- a/src/components/Leftbar/Builds.vue
+++ b/src/components/Leftbar/Builds.vue
@@ -97,7 +97,7 @@ function saveCurrentBuild() {
     console.log("Saving current...");
 
     const newStats = {
-        jobName: props.character.data.constructor.name,
+        jobName: Utils.getJobName(props.character.data.jobId),
         newlevel: props.character.data.level,
         str: props.character.data.str,
         sta: props.character.data.sta,

--- a/src/components/Leftbar/Character.vue
+++ b/src/components/Leftbar/Character.vue
@@ -18,7 +18,7 @@ const inputBuffer = reactive({
     assistBuffs: false,
     premiumItems: false,
     classBuffs: false,
-    jobName: props.character.data.constructor.name,
+    jobName: Utils.getJobName(props.character.data.jobId)
 });
 
 window.addEventListener("keypress", (e) => {
@@ -97,7 +97,7 @@ function applyStats() {
 
 function resetCharacter() {
     changeJob("Vagrant");
-    inputBuffer.jobName = props.character.data.constructor.name;
+    inputBuffer.jobName = Utils.getJobName(props.character.data.jobId);
     inputBuffer.newLevel = 1;
     inputBuffer.addStr = 0;
     inputBuffer.addSta = 0;
@@ -146,7 +146,7 @@ function updateStatPoints() {
 watch(
     () => props.character.data,
     () => {
-        inputBuffer.jobName = props.character.data.constructor.name;
+        inputBuffer.jobName = Utils.getJobName(props.character.data.jobId);
     }
 );
 

--- a/src/components/Leftbar/Equipment.vue
+++ b/src/components/Leftbar/Equipment.vue
@@ -31,7 +31,7 @@ function updateDropdowns() {
     shields.data = Utils.getShields().sort(Utils.sortByLevel);
 }
 
-watch(() => props.character.data.constructor.name, updateDropdowns);
+watch(() => props.character.data.jobId, updateDropdowns);
 
 watch(
     () => props.character.data.mainhand,


### PR DESCRIPTION
This aims to address #76 

The issue here is that `jobName` is being stored in `props.character.data.constructor.name`, however `constructor.name` is mangled as part of Vite's minification (which doesn't happen when one runs `npm run dev`). This makes sense, given that trying to store data as a field on a constructor itself is probably not what one wants to do. 

One solution here would've been to adjust the Vite config to add an exclusion for this field, but it that struck me as more of a band-aid.

The approach I've opted for here, is to just fetch the `jobName` from `getJobName` whenever the `jobId` is adjusted.

I'm not privy to the reason for using `constructor.name` initially, so feedback is welcome.