### PR TITLE
Add Statscroll/StatAwakes Implementation

### DIFF
--- a/src/components/itemedit.jsx
+++ b/src/components/itemedit.jsx
@@ -12,7 +12,6 @@ import skillAwakes from '../assets/SkillAwakes.json';
 import { AlwaysStencilFunc } from 'three';
 
 function ItemEdit({ itemElem }) {
-    console.log(itemElem)
     const [state, setState] = useState(false);
     const { showSearch } = useSearch();
     const { i18n } = useTranslation();

--- a/src/components/itemedit.jsx
+++ b/src/components/itemedit.jsx
@@ -258,14 +258,12 @@ function ItemEdit({ itemElem }) {
 
     function setStatAwakeOption(index, optionId) { 
         const parameter = getPossibleStatAwakeningParameter(index, optionId)[optionId];
-        console.log(parameter)
+
         const foundAwake = Utils.getAvailableStatAwakeOptions(itemElem?.statAwake).find((option) => {
-            const optionParameters = option.abilities.map((a) => a.parameter)
+            const abilityIndex = option.abilities.findIndex((e) => e.parameter === parameter);
+            if(abilityIndex < 0) return false;
 
-            const indexOfParameter = optionParameters.indexOf(parameter);
-            if(indexOfParameter < 0) return false; 
-
-            if(option.abilities[indexOfParameter].add != 1) {
+            if(option.abilities[abilityIndex].add != 1) {
                 return false;
             }
 

--- a/src/components/itemedit.jsx
+++ b/src/components/itemedit.jsx
@@ -9,7 +9,6 @@ import NumberInput from './numberinput';
 import * as Utils from '../flyff/flyffutils';
 import blessings from '../assets/Blessings.json';
 import skillAwakes from '../assets/SkillAwakes.json';
-import { AlwaysStencilFunc } from 'three';
 
 function ItemEdit({ itemElem }) {
     const [state, setState] = useState(false);

--- a/src/flyff/flyffentity.js
+++ b/src/flyff/flyffentity.js
@@ -1057,6 +1057,17 @@ export default class Entity {
                     total += ability.add;
                 }
             }
+
+            // statscrolls
+            if(itemElem.statAwake) {
+                for(const ability of itemElem.statAwake.abilities) {
+                    if(ability.parameter != stat || ability.rate != rate) {
+                        continue;
+                    }
+
+                    total += ability.add;
+                }
+            }
         }
 
         // Armor set stuff

--- a/src/flyff/flyffitemelem.js
+++ b/src/flyff/flyffitemelem.js
@@ -16,6 +16,7 @@ export default class ItemElem {
     originAwake = null;
     skillAwake = null;
     petStats = { F: 1, E: null, D: null, C: null, B: null, A: null, S: null }; // default value
+    statAwake = null;
 
 
     constructor(itemProp) {
@@ -117,6 +118,13 @@ export default class ItemElem {
      */
     isSkillAwakeAble() {
         return this.itemProp.category == "weapon" || this.itemProp.subcategory == "shield";
+    }
+
+    /**
+     * @returns Whether or not this item can be stat awakened.
+     */
+    isStatAwakeAble() {
+        return this.itemProp.category == "weapon" || this.itemProp.subcategory == "shield" || this.itemProp.category == "armor"; 
     }
 
     /**

--- a/src/flyff/flyfftooltip.jsx
+++ b/src/flyff/flyfftooltip.jsx
@@ -62,7 +62,7 @@ function setupItem(itemElem, i18n) {
     out.push(<span style={{
         fontWeight: 700,
         color: Utils.getItemNameColor(itemProp)
-    }}>{itemProp.name[shortLanguageCode] ?? itemProp.name.en}</span>);
+    }}>{itemProp.name[shortLanguageCode] ?? itemProp.name.en} {itemElem.statAwake?.title[shortLanguageCode] ?? itemElem.statAwake?.title.en}</span>);
 
     // TODO: Origin awakes (STA+, etc.)
 
@@ -235,6 +235,12 @@ function setupItem(itemElem, i18n) {
     if (itemProp.possibleRandomStats != undefined) {
         for (const stat of itemElem.randomStats) {
             out.push(<span style={{ color: "#ffff00" }}><br />{stat.parameter}+{stat.value}{stat.rate ? "%" : ""}</span>);
+        }
+    }
+
+    if(itemElem.statAwake != null) {
+        for(const ability of itemElem.statAwake.abilities) {
+            out.push(<span><br />{`${ability.parameter} +${ability.add}`}</span>)
         }
     }
 

--- a/src/flyff/flyffutils.js
+++ b/src/flyff/flyffutils.js
@@ -6,6 +6,7 @@ import classes from "../assets/Classes.json";
 import equipSets from "../assets/EquipSets.json";
 import partySkills from "../assets/PartySkills.json";
 import upgradeBonus from "../assets/UpgradeBonus.json";
+import statAwakes from "../assets/StatAwakes.json"
 
 export const JOBS = {
     9686: 0, // Vagrant
@@ -315,4 +316,29 @@ export function getGuid() {
     return ([1e7] + -1e3 + -4e3 + -8e3 + -1e11).replace(/[018]/g, (c) =>
         (c ^ (crypto.getRandomValues(new Uint8Array(1))[0] & (15 >> (c / 4)))).toString(16)
     );
+}
+
+/**
+ * Gets the possible StatAwake Options based on the current awake
+ * e.g. current is str+3, than return all options that also include str+3
+ */
+export function getAvailableStatAwakeOptions(currentStatAwake, checkAddValue = true) {
+    if(currentStatAwake == null) {
+        return statAwakes;
+    }
+
+    const currentAbilitiesFormatted = currentStatAwake.abilities.map((e) => `${e.parameter}${checkAddValue ? e.add : ''}${e.rate}`)
+    const possibleStatOptions = statAwakes.filter((nextStatAwake) => {
+        const nextAbilitiesFormatted = nextStatAwake.abilities.map((e) => `${e.parameter}${checkAddValue ? e.add : ''}${e.rate}`)
+
+        for(const currentAbilityFormatted of currentAbilitiesFormatted) {
+            if(!nextAbilitiesFormatted.includes(currentAbilityFormatted)) {
+                return false;
+            }
+        }
+
+        return true;
+    })
+
+    return possibleStatOptions;
 }

--- a/src/flyff/flyffutils.js
+++ b/src/flyff/flyffutils.js
@@ -7,7 +7,6 @@ import equipSets from "../assets/EquipSets.json";
 import partySkills from "../assets/PartySkills.json";
 import upgradeBonus from "../assets/UpgradeBonus.json";
 import statAwakes from "../assets/StatAwakes.json"
-import { cloneUniformsGroups } from "three/src/renderers/shaders/UniformsUtils.js";
 
 export const JOBS = {
     9686: 0, // Vagrant

--- a/src/flyff/flyffutils.js
+++ b/src/flyff/flyffutils.js
@@ -7,6 +7,7 @@ import equipSets from "../assets/EquipSets.json";
 import partySkills from "../assets/PartySkills.json";
 import upgradeBonus from "../assets/UpgradeBonus.json";
 import statAwakes from "../assets/StatAwakes.json"
+import { cloneUniformsGroups } from "three/src/renderers/shaders/UniformsUtils.js";
 
 export const JOBS = {
     9686: 0, // Vagrant
@@ -327,10 +328,10 @@ export function getAvailableStatAwakeOptions(currentStatAwake, checkAddValue = t
         return statAwakes;
     }
 
-    const currentAbilitiesFormatted = currentStatAwake.abilities.map((e) => `${e.parameter}${checkAddValue ? e.add : ''}${e.rate}`)
+    const currentAbilitiesFormatted = currentStatAwake.abilities.filter(e => e).map((e) => `${e.parameter}${checkAddValue ? e.add : ''}${e.rate}`)
     const possibleStatOptions = statAwakes.filter((nextStatAwake) => {
         const nextAbilitiesFormatted = nextStatAwake.abilities.map((e) => `${e.parameter}${checkAddValue ? e.add : ''}${e.rate}`)
-
+        
         for(const currentAbilityFormatted of currentAbilitiesFormatted) {
             if(!nextAbilitiesFormatted.includes(currentAbilityFormatted)) {
                 return false;
@@ -341,4 +342,14 @@ export function getAvailableStatAwakeOptions(currentStatAwake, checkAddValue = t
     })
 
     return possibleStatOptions;
+}
+
+export function getIndexOfParameter(parameter, statAwake) {
+    for(const [index, abilitiy] of statAwake.abilities) {
+        if(abilitiy.parameter == parameter) {
+            return index;
+        }
+    }
+
+    return 0; 
 }


### PR DESCRIPTION
Was trying to use only (and no other) options than what StatAwakes offers in its abilitites to ensure the api data is single source of truth. Caused some kinda funky util-functions, but so far it's fully functional and components adapt to all available options (and it's min/max) based on the current selection. I'll still keep it as a draft and look into some refactoring tomorrow. Me tired yes yes

1 little _issue_ is still present, but nothing fatal: 
- When you click `None` on any of the lines, it resets the entire StatAwake. 

![chrome_365046SzeaJlgE](https://github.com/user-attachments/assets/5fb51915-8931-4644-9ade-92a49ea343c3)

