### PR TITLE
Minor fixes

### DIFF
--- a/src/components/itemedit.jsx
+++ b/src/components/itemedit.jsx
@@ -225,6 +225,16 @@ function ItemEdit({ itemElem }) {
         e.stopPropagation();
     }
 
+    function clearPiercing(i) {
+        itemElem.piercings.splice(i, 1);
+        setState(!state);
+    }
+
+    function clearJewel(i) {
+        itemElem.ultimateJewels.splice(i, 1);
+        setState(!state);
+    }
+
     return (
         <div className="item-edit">
             <div id="edit-header">
@@ -358,7 +368,7 @@ function ItemEdit({ itemElem }) {
                         {
                             Array.from({ length: itemElem.getMaximumPiercingSlots() }, (_, i) => (
                                 <div key={i} onClick={() => setPiercingSlot(i)}>
-                                    <Slot className={"slot-item slot-editable"} content={itemElem.piercings[i]} />
+                                    <Slot className={"slot-item slot-editable"} content={itemElem.piercings[i]} onRemove={() => clearPiercing(i)} />
                                     {
                                         i == itemElem.piercings.length - 1 &&
                                         <button className="flyff-button icon" onClick={fillPiercings}>
@@ -381,7 +391,7 @@ function ItemEdit({ itemElem }) {
                         {
                             Array.from({ length: itemElem.getMaximumUltimateJewelSlots() }, (_, i) => (
                                 <div key={i} onClick={() => setJewelSlot(i)}>
-                                    <Slot className={"slot-item slot-editable"} content={itemElem.ultimateJewels[i]} />
+                                    <Slot className={"slot-item slot-editable"} content={itemElem.ultimateJewels[i]} onRemove={() => clearJewel(i)} />
                                 </div>
                             ))
                         }

--- a/src/flyff/flyfftooltip.jsx
+++ b/src/flyff/flyfftooltip.jsx
@@ -385,24 +385,29 @@ function setupItem(itemElem, i18n) {
 
             const bonusStyle = { color: "#ff9d00" };
             const bonuses = {};
+
+            // Accumulate all bonuses first then emit their sum
             for (const bonus of set.bonus) {
                 if (bonus.equipped > equippedCount) {
                     continue;
                 }
 
-                // Use the largest bonus
-                if (bonuses[bonus.ability.parameter] == undefined) {
-                    bonuses[bonus.ability.parameter] = bonus.ability.add;
-                }
-                else if (bonuses[bonus.ability.parameter] < bonus.ability.add) {
-                    bonuses[bonus.ability.parameter = bonus.ability.add];
+                const bonusKey = `${bonus.ability.parameter}.${bonus.ability.rate ? 'Y' : 'N'}`;
+
+                if (bonuses[bonusKey] == undefined) {
+                    bonuses[bonusKey] = bonus.ability.add;
                 }
                 else {
-                    continue;
+                    bonuses[bonusKey] += bonus.ability.add;
                 }
+            }
 
-                out.push(<span style={bonusStyle}><br />Set Effect: {bonus.ability.parameter} +{bonus.ability.add}</span>);
-                if (bonus.ability.rate) {
+            for (const [key, bonus] of Object.entries(bonuses)) {
+                const [parameter, rateString] = key.split('.');
+                const rate = rateString === 'Y';
+
+                out.push(<span style={bonusStyle}><br />Set Effect: {parameter} +{bonus}</span>);
+                if (rate) {
                     out.push(<span style={bonusStyle}>%</span>);
                 }
             }


### PR DESCRIPTION
Hi

This PR:
- Fixes the skill point calculations for all levels and specifically fixes the bonus points for merc (60 instead of 40)
- Adds `onRemove` for jewels and piercing cards
- Changes the way set bonuses are calculated so they are accumulated like they should, instead of taking the largest bonus
  - The UI change is slightly different, meant to show the accumulated bonuses in one stat line instead of multiple
- Adds ultimate jewels to stat calculations
- Adds weapon awake to stat calculations (for e.g. healing %)