### PR TITLE
Align stats order and update translations

### DIFF
--- a/public/locales/zh-CN/translation.json
+++ b/public/locales/zh-CN/translation.json
@@ -53,7 +53,12 @@
     "search_personal_housing_npc": "个人小屋 NPC",
     "search_couple_housing_npc": "情侣小屋 NPC",
     "search_guild_housing_npc": "公会小屋 NPC",
-    "enable_swordcross": "启用 刺伤",
-    "enable_waterbomb": "启用 水弹",
-    "enable_lifesteal": "启用 生命吸取"
+    "enable_swordcross": "使用 刺伤",
+    "enable_waterbomb": "使用 水弹",
+    "enable_lifesteal": "使用 生命吸取",
+    "enable_missing": "使用 闪避",
+    "enable_blocking": "使用 格档",
+    "enable_party_leader": "剧团团长",
+    "your_health": "你的生命值",
+    "target_health": "目标的生命值"
 }

--- a/public/locales/zh-TW/translation.json
+++ b/public/locales/zh-TW/translation.json
@@ -53,7 +53,12 @@
     "search_personal_housing_npc": "個人小屋 NPC",
     "search_couple_housing_npc": "情侶小屋 NPC",
     "search_guild_housing_npc": "公會小屋 NPC",
-    "enable_swordcross": "啟用 Swordcross",
-    "enable_waterbomb": "啟用 Waterbomb",
-    "enable_lifesteal": "啟用 Lifesteal"
+    "enable_swordcross": "使用 劍光交錯 Swordcross",
+    "enable_waterbomb": "使用 水炸彈 Waterbomb",
+    "enable_lifesteal": "使用 生命偷取 Lifesteal",
+    "enable_missing": "使用 閃避 Missing",
+    "enable_blocking": "使用 格檔 Blocking",
+    "enable_party_leader": "劇團團長",
+    "your_health": "你的生命值",
+    "target_health": "目標的生命值"
 }

--- a/src/components/skilltree.jsx
+++ b/src/components/skilltree.jsx
@@ -126,7 +126,8 @@ function SkillTree() {
             1029, // cannon ball
             6858, // accuracy
             579,  // protect
-            9047 // spirit fortune
+            9047, // spirit fortune
+            6845  // geburah tiphreth
         ];
 
         for (const id of buffs) {

--- a/src/tabs/calculations.jsx
+++ b/src/tabs/calculations.jsx
@@ -226,13 +226,13 @@ function Calculations() {
     return (
         <div id="calculations">
             <div id="basic-stats">
-                <BasicStat title={"Stamina"} value={Context.player.getBaseStat("sta")}
-                    information={"This is your total stamina, including any bonuses from equipment or elsewhere."}
+                <BasicStat title={"Strength"} value={Context.player.getBaseStat("str")}
+                    information={"This is your total strength, including any bonuses from equipment or elsewhere."}
                     sourceLink={"https://github.com/Frostiae/Flyffulator/blob/main/src/flyff/flyffentity.js#L290"}
                 />
 
-                <BasicStat title={"Strength"} value={Context.player.getBaseStat("str")}
-                    information={"This is your total strength, including any bonuses from equipment or elsewhere."}
+                <BasicStat title={"Stamina"} value={Context.player.getBaseStat("sta")}
+                    information={"This is your total stamina, including any bonuses from equipment or elsewhere."}
                     sourceLink={"https://github.com/Frostiae/Flyffulator/blob/main/src/flyff/flyffentity.js#L290"}
                 />
 


### PR DESCRIPTION
Hi

This PR includes 3 small updates:
- Align stats order with in-game on calculations tab
- Update zh-TW and zh-CN translations
- Add Geburah Tiphreth to RM Buffs

</br>

### Align stats order with in-game on calculations tab
![image](https://github.com/user-attachments/assets/7ca0582a-b2e9-434a-b8d1-64ff73d181b3)
to
![image](https://github.com/user-attachments/assets/5269b79f-9b34-4e8f-aad1-7a0766d05e51)
