### PR TITLE
Fix skill tooltip display

### DIFF
--- a/src/components/skilltree.jsx
+++ b/src/components/skilltree.jsx
@@ -8,6 +8,7 @@ import NumberInput from "./numberinput";
 import Context from "../flyff/flyffcontext";
 import SkillTreeIcon from "./skilltreeicon";
 import * as Utils from "../flyff/flyffutils";
+import SkillElem from "../flyff/flyffskillelem";
 
 function SkillTree() {
     const { showSearch } = useSearch();
@@ -158,8 +159,8 @@ function SkillTree() {
         setRefresh(!refresh);
     }
 
-    function removeSkill(skill) {
-        delete Context.player.activeBuffs[skill.id];
+    function removeSkill(skillElem) {
+        delete Context.player.activeBuffs[skillElem.skillProp.id];
         setRefresh(!refresh);
     }
 
@@ -207,7 +208,7 @@ function SkillTree() {
                                                 <SkillTreeIcon
                                                     clickHandle={(e) => clickSkill(skill, 1, e)}
                                                     rightClickHandle={(e) => clickSkill(skill, -1, e)}
-                                                    skill={skill}
+                                                    skillElem={new SkillElem(skill)}
                                                     key={skill.id}
                                                     disabled={!Context.player.canUseSkill(skill)}
                                                     level={Context.player.getSkillLevel(skill.id)}
@@ -293,7 +294,7 @@ function SkillTree() {
                 <div className="buffs-container">
                     {
                         Object.entries(Context.player.activeBuffs).map(([id,]) =>
-                            <Slot key={id} className={"slot-skill"} content={Utils.getSkillById(id)} onRemove={removeSkill} />
+                            <Slot key={id} className={"slot-skill"} content={new SkillElem(Utils.getSkillById(id), true)} onRemove={removeSkill} />
                         )
                     }
                 </div>

--- a/src/components/skilltreeicon.jsx
+++ b/src/components/skilltreeicon.jsx
@@ -3,7 +3,7 @@ import { useTooltip } from '../tooltipcontext';
 import { createTooltip } from '../flyff/flyfftooltip';
 import { useTranslation } from "react-i18next";
 
-function SkillTreeIcon({ skill, disabled, level, clickHandle, rightClickHandle }) {
+function SkillTreeIcon({ skillElem, disabled, level, clickHandle, rightClickHandle }) {
     const { showTooltip, hideTooltip } = useTooltip();
     const slotRef = useRef(null);
     const { i18n } = useTranslation();
@@ -12,17 +12,17 @@ function SkillTreeIcon({ skill, disabled, level, clickHandle, rightClickHandle }
         shortCode = i18n.resolvedLanguage.split('-')[0];
     }
 
-    const levelText = level == skill.levels.length ? "MAX" : level;
+    const levelText = level == skillElem.skillProp.levels.length ? "MAX" : level;
 
     function toggleTooltip(enabled) {
-        if (skill == null) {
+        if (skillElem == null) {
             return;
         }
 
         if (enabled) {
             const settings = {
                 rect: slotRef.current.getBoundingClientRect(),
-                text: createTooltip(skill, i18n)
+                text: createTooltip(skillElem, i18n)
             };
             showTooltip(settings);
         }
@@ -31,8 +31,8 @@ function SkillTreeIcon({ skill, disabled, level, clickHandle, rightClickHandle }
         }
     }
 
-    const xPos = skill.treePosition.x * 2;
-    const yPos = skill.treePosition.y * 2;
+    const xPos = skillElem.skillProp.treePosition.x * 2;
+    const yPos = skillElem.skillProp.treePosition.y * 2;
 
     return (
         <div onClick={clickHandle} onContextMenu={rightClickHandle} className={`skill-tree-icon ${disabled && "disabled"} ${level > 0 && "active"}`}
@@ -42,9 +42,9 @@ function SkillTreeIcon({ skill, disabled, level, clickHandle, rightClickHandle }
             ref={slotRef}
         >
             <img
-                key={skill.id}
-                src={`https://api.flyff.com/image/skill/colored/${skill.icon}`}
-                alt={skill.name[shortCode] ?? skill.name.en}
+                key={skillElem.skillProp.id}
+                src={`https://api.flyff.com/image/skill/colored/${skillElem.skillProp.icon}`}
+                alt={skillElem.skillProp.name[shortCode] ?? skillElem.skillProp.name.en}
                 style={{
                     width: 50, height: 50,
                     transform: "scale(1.15)"

--- a/src/components/slot.jsx
+++ b/src/components/slot.jsx
@@ -52,8 +52,11 @@ function Slot({ backgroundIcon, content, className, onRemove }, ref) {
         content != null &&
         <>
           {
-            (content.itemProp != undefined && content.passive == undefined) ? 
+            (content.itemProp != undefined && content.passive == undefined) ?
             <img src={`https://api.flyff.com/image/item/${content.itemProp.icon}`} draggable={false} id="slot-content" />
+            :
+            (content.skillProp != undefined) ?
+            <img src={`https://api.flyff.com/image/skill/colored/${content.skillProp.icon}`} draggable={false} id="slot-content" />
             :
             <img src={`https://api.flyff.com/image/skill/colored/${content.icon}`} draggable={false} id="slot-content" />
           }

--- a/src/flyff/flyffentity.js
+++ b/src/flyff/flyffentity.js
@@ -434,8 +434,37 @@ export default class Entity {
             return false;
         }
 
-        if (skillProp.weapon != undefined && this.equipment.mainhand.itemProp.subcategory != skillProp.weapon) {
-            return false;
+        if (skillProp.weapon != undefined) {
+            switch (skillProp.weapon) {
+                case "enchantedweapon":
+                    if (this.equipment.mainhand.itemProp.category != "weapon") {
+                        return false;
+                    }
+                    break;
+                case "shield":
+                    if (!this.equipment.offhand ||
+                        this.equipment.offhand.itemProp.subcategory != "shield") {
+                        return false;
+                    }
+                    break;
+                case "wandorstaff":
+                    if (this.equipment.mainhand.itemProp.subcategory != "wand" &&
+                        this.equipment.mainhand.itemProp.subcategory != "staff") {
+                        return false;
+                    }
+                    break;
+                case "yoyoorbow":
+                    if (this.equipment.mainhand.itemProp.subcategory != "yoyo" &&
+                        this.equipment.mainhand.itemProp.subcategory != "bow") {
+                        return false;
+                    }
+                    break;
+                default:
+                    if (this.equipment.mainhand.itemProp.subcategory != skillProp.weapon) {
+                        return false;
+                    }
+                    break;
+            }
         }
 
         if (skillProp.requirements != undefined) {

--- a/src/flyff/flyffskillelem.js
+++ b/src/flyff/flyffskillelem.js
@@ -1,0 +1,12 @@
+/**
+ * An instance of an in-game skill.
+ */
+export default class SkillElem {
+    skillProp = null; // Static game skill property from the API
+    isFromBuffer = false;
+
+    constructor(skillProp, isFromBuffer = false) {
+        this.skillProp = skillProp;
+        this.isFromBuffer = isFromBuffer;
+    }
+}

--- a/src/flyff/flyfftooltip.jsx
+++ b/src/flyff/flyfftooltip.jsx
@@ -722,9 +722,12 @@ function setupSkillFromBuffer(skill, i18n){
             let pveOrPvp = (ability.pvp != undefined && ability.pve != undefined)
                 ? (ability.pvp && !ability.pve ? " (PVP)" : !ability.pvp && ability.pve ? " (PVE)" : "")
                 : "";
-            ability.parameter == "attribute" ?
-                out.push(<span style={abilityStyle}><br />{ability.attribute}</span>) :
+            if (ability.parameter == "attribute") {
+                out.push(<span style={abilityStyle}><br />{ability.attribute}</span>);
+            }
+            else {
                 out.push(<span style={abilityStyle}><br />{ability.parameter}{ability.set != undefined ? "=" : ability.add && ability.add > 0 ? "+" : ""}{ability.set != undefined ? ability.set : ability.add && ability.add + add}{ability.rate && "%"}{pveOrPvp}</span>);
+            }
             if (add > 0) {
                 out.push(<span style={{ color: "#ffaa00" }}> ({ability.add}+{add})</span>);
             }
@@ -751,9 +754,15 @@ function setupSkillFromBuffer(skill, i18n){
                 }
             }
         }
+        const hours = Math.floor(duration / 3600);
+        const mins = Math.floor((duration % 3600) / 60);
         const secs = duration % 60;
-        const mins = Math.floor(duration / 60);
-        out.push(<span><br/>{String(mins).padStart(2, "0")}:{String(secs).padStart(2, "0")}</span>);
+        if (hours > 0) {
+            out.push(<span><br/>{String(hours).padStart(2, "0")}:{String(mins).padStart(2, "0")}:{String(secs).padStart(2, "0")}</span>);
+        }
+        else {
+            out.push(<span><br/>{String(mins).padStart(2, "0")}:{String(secs).padStart(2, "0")}</span>);
+        }
     }
 
     return (<div>{out.map((v, i) => <span key={i}>{v}</span>)}</div>);
@@ -773,6 +782,12 @@ function setupPartySkill(partySkill, i18n) {
 
     out.push(<span style={{ color: "#2fbe6d", fontWeight: 600 }}>{partySkill.name[shortLanguageCode] ?? partySkill.name.en}</span>);
     out.push(`\n${partySkill.description[shortLanguageCode] ?? partySkill.description.en}`)
+
+    if (partySkill.duration != undefined) {
+        const mins = Math.floor(partySkill.duration / 60);
+        const secs = partySkill.duration % 60;
+        out.push(<span><br/>{String(mins).padStart(2, "0")}:{String(secs).padStart(2, "0")}</span>);
+    }
 
     return (<div>{out.map((v, i) => <span key={i}>{v}</span>)}</div>);
 }


### PR DESCRIPTION
Hi

This PR includes 2 fixes:

- Fix weapon and subcategory checks for canUseSkill

- Fix display of Buff Tooltips in SkillTree and Active Buffs :

   - Separate skill objects from the **SkillTree** and **Active Buffs**. 
   -  **Active Buffs** will still use the max level and show the abilities based on the buffer's stats.
   - Add PVP and PVE display to the *Scales*.
   - Remove "+" for negative *ability.add*.

### SkillTree
#### Display the abilities at each level.
![image](https://github.com/user-attachments/assets/a0b1e7ca-92e1-47ab-8ab7-de5464d30578)

#### Display the PvE and PvP scales.
![image](https://github.com/user-attachments/assets/417ccb56-0ca7-4792-a76c-0cb9980e3b07)

#### Correctly display the negative stat.
![image](https://github.com/user-attachments/assets/561206cd-005b-46ce-9607-5f0caa659627)

### Acive Buffs
#### Display the abilities based on the buffer's stats.
![image](https://github.com/user-attachments/assets/089c82e1-666d-4c26-9b81-f7a709cafecf)
