### PR TITLE
fix: use display: contents; to fix dropdown options not showing in safari

### DIFF
--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -195,7 +195,7 @@ input {
 img.info-icon {
   width: 16px;
   opacity: 0.6;
-  
+
   &:hover {
     opacity: 1.0;
   }
@@ -211,7 +211,7 @@ img.info-icon {
   position: relative;
   box-shadow: 0 0 5px black;
   width: fit-content;
-  
+
   &:hover {
     cursor: pointer;
     outline: 1px solid v.$border-color;
@@ -246,6 +246,16 @@ img.info-icon {
     z-index: 1000;
 
     option {
+    display: contents;
+    /* Chrome UA styles */
+    /* Adding back for consistency */
+    font-weight: normal;
+    padding-block-start: 0px;
+    padding-block-end: 1px;
+    min-block-size: 1.2em;
+    padding-inline: 2px;
+    white-space: nowrap;
+
       &:hover {
         color: v.$border-color;
         cursor: pointer;


### PR DESCRIPTION
fixes #119 

Tested on MacOS Tahoe 26 developer beta

Safari v19
![image](https://github.com/user-attachments/assets/c199a50c-0e0b-4307-b8d4-b14db822b82f)

Chrome Version 137.0.7151.69 (just to show that it still works)
![image](https://github.com/user-attachments/assets/ecd8957b-3fb1-48ef-82bf-b6c6b816aa76)
