### PR TITLE
Fix minimum and maximum block

### DIFF
--- a/src/components/calculations/calculations.jsx
+++ b/src/components/calculations/calculations.jsx
@@ -417,13 +417,13 @@ function Calculations() {
                     sourceLink={"https://github.com/Frostiae/Flyffulator/blob/main/src/flyff/flyffentity.js#L535"}
                 />
 
-                <BasicStat title={"Melee Block"} value={Utils.clamp(Context.player.getBlockChance(false, Context.defender), 7.5, 93.75)}
+                <BasicStat title={"Melee Block"} value={Utils.clamp(Context.player.getBlockChance(false, Context.defender), 6.25, 92.5)}
                     information={"How often you block melee attacks from the current target.\n\nThis value may be different than the one you see in the character window as it takes everything into account, such as minimums, maximums and the opponent's stats. This is your true block rate."}
                     sourceLink={"https://github.com/Frostiae/Flyffulator/blob/main/src/flyff/flyffentity.js#L965"}
                     percentage
                 />
 
-                <BasicStat title={"Ranged Block"} value={Utils.clamp(Context.player.getBlockChance(true, Context.defender), 7.5, 93.75)}
+                <BasicStat title={"Ranged Block"} value={Utils.clamp(Context.player.getBlockChance(true, Context.defender), 6.25, 92.5)}
                     information={"How often you block ranged attacks from the current target.\n\nThis value may be different than the one you see in the character window as it takes everything into account, such as minimums, maximums and the opponent's stats. This is your true block rate."}
                     sourceLink={"https://github.com/Frostiae/Flyffulator/blob/main/src/flyff/flyffentity.js#L965"}
                     percentage

--- a/src/flyff/flyffdamagecalculator.js
+++ b/src/flyff/flyffdamagecalculator.js
@@ -790,7 +790,7 @@ function getBlockFactor() {
             return 1;
         }
 
-        // 7.5% chance to block the attack
+        // 6.25% chance to block the attack
         if (r >= 75) {
             return minBlock;
         }
@@ -802,7 +802,7 @@ function getBlockFactor() {
     else {
         const r = Math.floor(Math.random() * 100);
 
-        // 5% chance to take full damage
+        // 6% chance to take full damage
         if (r <= 5) {
             return 1;
         }

--- a/src/flyff/flyffentity.js
+++ b/src/flyff/flyffentity.js
@@ -1349,8 +1349,8 @@ export default class Entity {
      */
     getBlockChance(ranged, attacker) {
         if (this.isPlayer()) {
-            // minimum of 7.5% chance to block
-            // maxmium of 93.75% chance to block
+            // minimum of 6.25% chance to block
+            // maximum of 92.5% chance to block
 
             // Block based on dex and level
             const attackerLevel = attacker.level == -1 ? this.level : attacker.level;


### PR DESCRIPTION
Hi!

This pull request fixes the display of the minimum and maximum values for Block in Calculations tab.

* Minimum Block
   ![image](https://github.com/user-attachments/assets/a954dc97-94a9-4b6f-b5a0-afdcfacc908b)

* Maximum Block
   ![image](https://github.com/user-attachments/assets/8fb80727-e3da-4ce5-bb13-c41764f94b45)
