### PR TITLE
Fix tooltip piercing bonuses

### DIFF
--- a/src/flyff/flyfftooltip.jsx
+++ b/src/flyff/flyfftooltip.jsx
@@ -454,7 +454,7 @@ function setupItem(itemElem, i18n) {
         }
 
         for (const ability of card.itemProp.abilities) {
-            if (ability.parameter in piercingBonuses) {
+            if (Utils.getStatNameByIdOrDefault(ability.parameter, i18n) in piercingBonuses) {
                 piercingBonuses[Utils.getStatNameByIdOrDefault(ability.parameter, i18n)].add += ability.add;
             }
             else {


### PR DESCRIPTION
Hi!

This pull request fixes the display of piercing bonuses for items in the Equipment tab.

<div align="center">

| Use 5 Thorn A cards |
| --- |
| <img width="460" height="244" alt="1" src="https://github.com/user-attachments/assets/2dffd603-dd96-4cb8-a7f6-ea5dc57ba070" /> |

| Before | After |
| --- | --- |
| <img width="299" height="650" alt="2" src="https://github.com/user-attachments/assets/eda1e058-afae-47e0-8a0f-f9796be9f95a" /> | <img width="300" height="651" alt="3" src="https://github.com/user-attachments/assets/bd4b815d-c92e-44d5-b3be-6c5880371e39" /> |

</div>