### PR TITLE
Add calculation for true block chance

### DIFF
--- a/src/components/calculations/calculations.jsx
+++ b/src/components/calculations/calculations.jsx
@@ -417,13 +417,13 @@ function Calculations() {
                     sourceLink={"https://github.com/Frostiae/Flyffulator/blob/main/src/flyff/flyffentity.js#L535"}
                 />
 
-                <BasicStat title={"Melee Block"} value={Utils.clamp(Context.player.getBlockChance(false, Context.defender), 6.25, 92.5)}
+                <BasicStat title={"Melee Block"} value={Context.player.getTrueBlockChance(false, Context.defender)}
                     information={"How often you block melee attacks from the current target.\n\nThis value may be different than the one you see in the character window as it takes everything into account, such as minimums, maximums and the opponent's stats. This is your true block rate."}
                     sourceLink={"https://github.com/Frostiae/Flyffulator/blob/main/src/flyff/flyffentity.js#L965"}
                     percentage
                 />
 
-                <BasicStat title={"Ranged Block"} value={Utils.clamp(Context.player.getBlockChance(true, Context.defender), 6.25, 92.5)}
+                <BasicStat title={"Ranged Block"} value={Context.player.getTrueBlockChance(true, Context.defender)}
                     information={"How often you block ranged attacks from the current target.\n\nThis value may be different than the one you see in the character window as it takes everything into account, such as minimums, maximums and the opponent's stats. This is your true block rate."}
                     sourceLink={"https://github.com/Frostiae/Flyffulator/blob/main/src/flyff/flyffentity.js#L965"}
                     percentage

--- a/src/flyff/flyffentity.js
+++ b/src/flyff/flyffentity.js
@@ -1412,6 +1412,32 @@ export default class Entity {
         }
     }
 
+    getTrueBlockChance(ranged, attacker) {
+        const blockChance = this.getBlockChance(ranged, attacker);
+        if (this.isPlayer()) {
+            if (blockChance <= 6) {
+                // minimum of 6.25% chance to block
+                return 6.25;
+            }
+            if (blockChance >= 75) {
+                // maximum of 92.5% chance to block
+                return 92.5;
+            }
+            return (blockChance - 1) / 80 * 100;
+        }
+        else {
+            if (blockChance <= 6) {
+                // minimum of 5% chance blockrate
+                return 5;
+            }
+            if (blockChance >= 95) {
+                // maximum of 94% chance blockrate
+                return 94;
+            }
+            return blockChance - 1;
+        }
+    }
+
     getStatScale(parameter, skillProp, level) {
         const levelProp = skillProp.levels[level];
         if (levelProp == undefined) {


### PR DESCRIPTION
Hi!

This pull request implements a calculation for the true block chance in the Calculations tab.

It adjusts the block rate display to show the actual probability directly, as the in-game display is inaccurate and the block rate on the Calculations tab currently requires further conversion.

<div align="center"><img width="674" height="638" alt="image" src="https://github.com/user-attachments/assets/05dc31c8-efc2-4e4f-ad84-dae552b941d9" /></div>

</br>

Correct me if there are any issues.

Thanks!