### PR TITLE
Fix skill awakening calculation for items

### DIFF
--- a/src/flyff/flyffentity.js
+++ b/src/flyff/flyffentity.js
@@ -996,7 +996,7 @@ export default class Entity {
 
             // Item awake (for e.g. healing)
             if (itemElem.skillAwake != undefined) {
-                if (itemElem.skillAwake.parameter === stat && rate) {
+                if ((itemElem.skillAwake.parameter === stat || targetStats.includes(itemElem.skillAwake.parameter)) && rate) {
                     total += itemElem.skillAwake.add;
                 }
             }


### PR DESCRIPTION
Hi!

This PR fixes an issue where stat values were not included in the calculation when using the shield's skill awakening.

It seems that the issue may only be affecting the block calculation.

Thank you!