### PR TITLE
Fix dropdown sizing, ultimate jewelry upgrade crash, and build save duplication

### DIFF
--- a/public/locales/de-DE/translation.json
+++ b/public/locales/de-DE/translation.json
@@ -4,6 +4,8 @@
     "import": "Importieren",
     "cancel": "Zurück",
     "build_share_save": "Speichern",
+    "build_share_save_as": "Speichern als",
+    "build_overwrite_confirm": "Ein Build namens \"{{name}}\" existiert bereits. Überschreiben?",
     "build_share_share": "Teilen",
     "build_share_import": "Importieren",
     "percent_loaded": "% loaded",

--- a/public/locales/en-US/translation.json
+++ b/public/locales/en-US/translation.json
@@ -4,6 +4,8 @@
     "import": "Import",
     "cancel": "Cancel",
     "build_share_save": "Save",
+    "build_share_save_as": "Save As",
+    "build_overwrite_confirm": "A build named \"{{name}}\" already exists. Overwrite it?",
     "build_share_share": "Share",
     "build_share_import": "Import",
     "percent_loaded": "% loaded",

--- a/public/locales/pt-BR/translation.json
+++ b/public/locales/pt-BR/translation.json
@@ -4,6 +4,8 @@
     "import": "Importar",
     "cancel": "Cancelar",
     "build_share_save": "Salvar",
+    "build_share_save_as": "Salvar como",
+    "build_overwrite_confirm": "Já existe uma build chamada \"{{name}}\". Sobrescrever?",
     "build_share_share": "Compartilhar",
     "build_share_import": "Importar",
     "percent_loaded": "% carregado",

--- a/public/locales/zh-CN/translation.json
+++ b/public/locales/zh-CN/translation.json
@@ -4,6 +4,8 @@
     "import": "导入",
     "cancel": "取消",
     "build_share_save": "保存",
+    "build_share_save_as": "另存为",
+    "build_overwrite_confirm": "已存在名为 \"{{name}}\" 的构建。要覆盖它吗？",
     "build_share_share": "分享",
     "build_share_import": "导入",
     "percent_loaded": "% 已加载",

--- a/public/locales/zh-TW/translation.json
+++ b/public/locales/zh-TW/translation.json
@@ -4,6 +4,8 @@
     "import": "匯入",
     "cancel": "取消",
     "build_share_save": "儲存",
+    "build_share_save_as": "另存為",
+    "build_overwrite_confirm": "已存在名為 \"{{name}}\" 的建構。要覆蓋它嗎？",
     "build_share_share": "分享",
     "build_share_import": "匯入",
     "percent_loaded": "% 已載入",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -108,13 +108,36 @@ function App() {
   }
 
   function save() {
-    // Crude way of saving for now
-    const buildName = prompt(t("enter_build_name"));
-    if (buildName == null || buildName.length == 0) {
+    // Quick save: overwrite the currently loaded build in place, no prompt.
+    if (loadedBuild != null && localStorage.getItem(loadedBuild) != null) {
+      localStorage.setItem(loadedBuild, Context.player.serialize());
+      setState(!state);
       return;
     }
 
-    const key = `${buildName}_${Utils.getGuid()}`;
+    // Nothing loaded to overwrite, fall back to naming a new build.
+    saveAs();
+  }
+
+  function saveAs() {
+    const buildName = prompt(t("enter_build_name"));
+    if (buildName == null || buildName.trim().length == 0) {
+      return;
+    }
+    const trimmedName = buildName.trim();
+
+    const existingKey = Object.entries(buildOptions).find(([, name]) => name === trimmedName)?.[0];
+    if (existingKey != null) {
+      if (!confirm(t("build_overwrite_confirm", { name: trimmedName }))) {
+        return;
+      }
+
+      localStorage.setItem(existingKey, Context.player.serialize());
+      loadBuild(existingKey);
+      return;
+    }
+
+    const key = `${trimmedName}_${Utils.getGuid()}`;
     localStorage.setItem(key, Context.player.serialize());
     loadBuild(key);
   }
@@ -215,6 +238,7 @@ function App() {
             </div>
             <div id="build-share">
               <button className='flyff-button' onClick={save}>{t("build_share_save")}</button>
+              <button className='flyff-button' onClick={saveAs}>{t("build_share_save_as")}</button>
               <div>
                 <button className='flyff-button' onClick={share}>{t("build_share_share")}</button>
                 <button className='flyff-button' onClick={() => setIsImporting(true)}>{t("build_share_import")}</button>

--- a/src/components/equipment/itemedit/itemedit.jsx
+++ b/src/components/equipment/itemedit/itemedit.jsx
@@ -260,17 +260,19 @@ function ItemEdit({ itemElem }) {
         itemElem.upgradeLevel = level;
 
         if (itemElem.itemProp.rarity === "ultimate") {
+            const possibleRandomStats = itemElem.itemProp.possibleRandomStats;
+
             if (level < 10) {
                 itemElem.randomStats.splice(3);
-            } else if (!itemElem.randomStats[3]) {
-                const stat = itemElem.itemProp.possibleRandomStats[Math.min(3, itemElem.itemProp.possibleRandomStats.length)];
+            } else if (possibleRandomStats != undefined && !itemElem.randomStats[3]) {
+                const stat = possibleRandomStats[Math.min(3, possibleRandomStats.length)];
                 itemElem.randomStats[3] = { ...stat, id: 3, value: halfStat(stat.parameter, Math.floor(stat.add + (stat.addMax - stat.add) / 2)) };
             }
 
             if (level < 6) {
                 itemElem.randomStats.splice(2);
-            } else if (!itemElem.randomStats[2]) {
-                const stat = itemElem.itemProp.possibleRandomStats[Math.min(2, itemElem.itemProp.possibleRandomStats.length)];
+            } else if (possibleRandomStats != undefined && !itemElem.randomStats[2]) {
+                const stat = possibleRandomStats[Math.min(2, possibleRandomStats.length)];
                 itemElem.randomStats[2] = { ...stat, id: 2, value: halfStat(stat.parameter, Math.floor(stat.add + (stat.addMax - stat.add) / 2)) };
             }
 

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -222,7 +222,7 @@ img.info-icon {
     align-items: center;
     justify-content: space-between;
     color: v.$border-color;
-    gap: 40px;
+    gap: 70px;
 
 
     img {
@@ -244,6 +244,7 @@ img.info-icon {
     max-height: 250px;
     overflow-y: scroll;
     z-index: 1000;
+    padding: 10px 20px;
 
     option {
     display: contents;


### PR DESCRIPTION
## Summary
- Fixed dropdowns being too small
- Fixed a crash when upgrading ultimate-rarity jewelry (e.g. Champion's Ring, Defender's Ring) past +5 — these items have no `possibleRandomStats`, unlike ultimate weapons/armor, which `setUpgradeLevel` assumed
- Saving a build always created a new duplicate entry, even with an identical name. "Save" now quick-saves the currently loaded build in place; a new "Save As" button prompts for a name and asks before overwriting an existing build with that name

## Test plan
- [x] Reproduced and verified the jewelry upgrade crash fix in a real browser (before/after)
- [x] Verified quick-save overwrites in place, Save As creates new builds, and Save As with a duplicate name prompts to overwrite instead of duplicating