### PR TITLE
Fix pet selection

### DIFF
--- a/src/components/shared/search.jsx
+++ b/src/components/shared/search.jsx
@@ -66,8 +66,7 @@ function Search() {
 
                         // only display actual pets, not skins or the ones with modified flags                        
                         if (item.category === "raisedpet") {
-                            const petFound = Object.values(pets).find((pet) => pet.petItemId === item.id);
-                            if (!petFound) {
+                            if (!Utils.getPetDefinitionByItemId(item.id)) {
                                 continue;
                             }
                         }


### PR DESCRIPTION
Fixes pet selection

Before:

`Uncaught ReferenceError: pets is not defined
at search (search.jsx:69:60)
at onChange (search.jsx:192:255)`

After:

<img width="773" height="503" alt="image" src="https://github.com/user-attachments/assets/bb8dd628-d460-4ada-849c-188c0b718b94" />
